### PR TITLE
Fix timeline selection overflow on short videos

### DIFF
--- a/src/content/overlay-wizard/components/TimelineScrubber.tsx
+++ b/src/content/overlay-wizard/components/TimelineScrubber.tsx
@@ -41,7 +41,8 @@ const TimelineScrubber: React.FC<TimelineScrubberProps> = ({
     const newValue = parseFloat(value.toFixed(1));
     const maxEnd = Math.min(startTime + newValue, duration);
     onRangeChange(startTime, maxEnd);
-    setDurationSliderValue(newValue);
+    // Set slider value to actual applied duration, not requested duration
+    setDurationSliderValue(maxEnd - startTime);
   };
 
   // Calculate slider constraints

--- a/src/content/wizard-styles.css
+++ b/src/content/wizard-styles.css
@@ -670,6 +670,7 @@
   cursor: pointer;
   margin-bottom: 20px;
   margin-top: 12px;
+  overflow: hidden;
 }
 
 .ytgif-timeline-background {

--- a/tests/e2e-mock/wizard-basic.spec.ts
+++ b/tests/e2e-mock/wizard-basic.spec.ts
@@ -557,4 +557,158 @@ test.describe('Mock E2E: Basic Wizard Tests', () => {
 
     console.log('✅ [Mock Test] Duplicate frame detection workflow validated!');
   });
+
+  // ========== Short Video Edge Case Tests ==========
+
+  test('Timeline handles short video boundary correctly - prevents overflow', async ({ page, mockServerUrl }) => {
+    test.setTimeout(60000);
+
+    const youtube = new YouTubePage(page);
+    const quickCapture = new QuickCapturePage(page);
+
+    // Use 10-second video to test short video edge cases
+    await youtube.navigateToVideo(getMockVideoUrl('medium', mockServerUrl));
+    await youtube.openGifWizard();
+    await quickCapture.waitForScreen();
+
+    console.log('[Mock Test] Testing short video boundary handling...');
+
+    // Step 1: First set duration to 2 seconds using the slider
+    const slider = page.locator('.ytgif-slider-input');
+    await slider.waitFor({ state: 'visible', timeout: 5000 });
+    await slider.fill('2');
+    await page.waitForTimeout(300);
+
+    console.log('[Mock Test] Set initial duration to 2s');
+
+    // Step 2: Now click timeline near the end (80% position = 8 seconds on 10s video)
+    // This will move the 2s selection window to end at the video end
+    const timelineBox = await page.locator('.ytgif-timeline-track').boundingBox();
+    if (!timelineBox) {
+      throw new Error('Timeline not visible');
+    }
+
+    const clickX = timelineBox.x + (0.8 * timelineBox.width);
+    const clickY = timelineBox.y + (timelineBox.height / 2);
+    await page.mouse.click(clickX, clickY);
+    await page.waitForTimeout(500);
+
+    console.log('[Mock Test] Clicked timeline at 80% position');
+
+    // Step 3: Get current slider max (should be ~2 seconds since we're near the end)
+    const maxAttrBefore = await slider.getAttribute('max');
+    console.log(`[Mock Test] Slider max after clicking near end: ${maxAttrBefore}s`);
+
+    // Step 4: Try to set duration beyond video bounds by manually triggering change event
+    // Note: We can't use .fill() because HTML5 range inputs reject out-of-range values
+    // So we directly dispatch a change event with the value
+    await slider.evaluate((el: HTMLInputElement) => {
+      el.value = '10';
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await page.waitForTimeout(500);
+
+    // Step 5: Verify slider shows actual applied duration, not requested
+    const sliderValue = await page.locator('.ytgif-slider-value').textContent();
+    console.log(`[Mock Test] Slider value after trying to set 10s: ${sliderValue}`);
+
+    // Should show clamped value (<=3s), NOT 10s
+    const displayedValue = parseFloat(sliderValue!.replace('s', ''));
+    expect(displayedValue).toBeLessThanOrEqual(4); // Should be clamped to remaining duration
+    expect(displayedValue).toBeGreaterThan(0);
+
+    // Step 6: Verify visual selection doesn't overflow container
+    const selection = await page.locator('.ytgif-timeline-selection').boundingBox();
+    const container = await page.locator('.ytgif-timeline-track').boundingBox();
+
+    if (selection && container) {
+      const selectionEnd = selection.x + selection.width;
+      const containerEnd = container.x + container.width;
+
+      console.log(`[Mock Test] Selection end: ${selectionEnd.toFixed(2)}, Container end: ${containerEnd.toFixed(2)}`);
+
+      // Selection should not extend beyond container (with 1px tolerance for rounding)
+      expect(selectionEnd).toBeLessThanOrEqual(containerEnd + 1);
+      console.log('✅ [Mock Test] Selection stays within bounds');
+    }
+
+    console.log('✅ [Mock Test] Timeline correctly handles short video boundary!');
+  });
+
+  test('Timeline slider value synchronizes with actual applied duration on short videos', async ({ page, mockServerUrl }) => {
+    test.setTimeout(60000);
+
+    const youtube = new YouTubePage(page);
+    const quickCapture = new QuickCapturePage(page);
+
+    // Use 10-second video
+    await youtube.navigateToVideo(getMockVideoUrl('medium', mockServerUrl));
+    await youtube.openGifWizard();
+    await quickCapture.waitForScreen();
+
+    console.log('[Mock Test] Testing slider value synchronization on short videos...');
+
+    // Step 1: Set duration to 1.5 seconds using the slider
+    const durationSlider = page.locator('.ytgif-slider-input');
+    await durationSlider.waitFor({ state: 'visible', timeout: 5000 });
+    await durationSlider.fill('1.5');
+    await page.waitForTimeout(300);
+
+    console.log('[Mock Test] Set initial duration to 1.5s');
+
+    // Step 2: Click near the end of the timeline (85% position = 8.5s on 10s video)
+    // This will move the 1.5s window to (8.5s, 10s)
+    const timelineBox = await page.locator('.ytgif-timeline-track').boundingBox();
+    if (!timelineBox) {
+      throw new Error('Timeline not visible');
+    }
+
+    const clickX = timelineBox.x + (0.85 * timelineBox.width);
+    const clickY = timelineBox.y + (timelineBox.height / 2);
+    await page.mouse.click(clickX, clickY);
+    await page.waitForTimeout(500);
+
+    console.log('[Mock Test] Clicked timeline at 85% position (~8.5s)');
+
+    // Step 3: Get current max value (should be ~1.5 seconds since we're at ~8.5s on 10s video)
+    const maxValue = await durationSlider.getAttribute('max');
+    console.log(`[Mock Test] Max slider value: ${maxValue}s`);
+
+    // Step 4: Try to set slider beyond the max (e.g., 10 seconds)
+    // Note: We can't use .fill() because HTML5 range inputs reject out-of-range values
+    // So we directly dispatch a change event with the value
+    await durationSlider.evaluate((el: HTMLInputElement) => {
+      el.value = '10';
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await page.waitForTimeout(500);
+
+    // Step 5: Verify slider value display shows clamped value, not requested value
+    let sliderValueDisplay = await page.locator('.ytgif-slider-value').textContent();
+    console.log(`[Mock Test] Slider value after requesting 10s: ${sliderValueDisplay}`);
+
+    // Extract numeric value
+    let displayedValue = parseFloat(sliderValueDisplay!.replace('s', ''));
+
+    // Should be clamped to max (<=2.5s), not 10s
+    expect(displayedValue).toBeLessThanOrEqual(3); // Should be clamped
+    expect(displayedValue).toBeGreaterThan(0);
+
+    console.log(`[Mock Test] ✅ Slider value correctly clamped to ${displayedValue}s (not 10s)`);
+
+    // Step 6: Set slider to a valid value within range
+    await durationSlider.fill('1');
+    await page.waitForTimeout(300);
+
+    // Verify slider value display matches
+    sliderValueDisplay = await page.locator('.ytgif-slider-value').textContent();
+    console.log(`[Mock Test] Slider value after setting to 1s: ${sliderValueDisplay}`);
+
+    displayedValue = parseFloat(sliderValueDisplay!.replace('s', ''));
+
+    // Should be ~1s
+    expect(Math.abs(displayedValue - 1.0)).toBeLessThan(0.2);
+
+    console.log('✅ [Mock Test] Slider value correctly synchronized with actual duration!');
+  });
 });

--- a/tests/unit/components/TimelineScrubber.test.tsx
+++ b/tests/unit/components/TimelineScrubber.test.tsx
@@ -80,8 +80,8 @@ describe('TimelineScrubber', () => {
       expect(slider).toHaveAttribute('max', '15');
     });
 
-    it('should respect video duration limit when slider changes', () => {
-      render(<TimelineScrubber {...defaultProps} duration={10} startTime={8} />);
+    it('should respect video duration limit when slider changes and display actual duration', () => {
+      const { container } = render(<TimelineScrubber {...defaultProps} duration={10} startTime={8} />);
       const slider = screen.getByRole('slider', { name: /GIF duration/i });
 
       // Try to set duration beyond video end
@@ -89,6 +89,10 @@ describe('TimelineScrubber', () => {
 
       // Should be clamped to remaining duration (10 - 8 = 2)
       expect(defaultProps.onRangeChange).toHaveBeenCalledWith(8, 10);
+
+      // Verify slider displays actual applied duration (2s), not requested duration (5s)
+      const valueDisplay = container.querySelector('.ytgif-slider-value');
+      expect(valueDisplay).toHaveTextContent('2.0s');
     });
 
     it('should disable slider for videos shorter than 1 second', () => {
@@ -105,6 +109,71 @@ describe('TimelineScrubber', () => {
 
       // Max should be min(20, 25-10) = 15
       expect(slider).toHaveAttribute('max', '15');
+    });
+
+    it('should handle edge case: start time very close to end of short video', () => {
+      // Start with a smaller duration first, then test overflow
+      const { container } = render(<TimelineScrubber {...defaultProps} duration={5} startTime={4.5} endTime={4.7} />);
+      const slider = screen.getByRole('slider', { name: /GIF duration/i });
+
+      // Max should be 0.5 seconds (5 - 4.5)
+      expect(slider).toHaveAttribute('max', '0.5');
+
+      // Verify initial slider displays current duration (0.2s)
+      let valueDisplay = container.querySelector('.ytgif-slider-value');
+      expect(valueDisplay).toHaveTextContent('0.2s');
+
+      // Try to set a long duration (10s) which exceeds both max slider (0.5s) and video end
+      fireEvent.change(slider, { target: { value: '10' } });
+
+      // Should be clamped to remaining video duration (0.5s)
+      expect(defaultProps.onRangeChange).toHaveBeenCalledWith(4.5, 5);
+
+      // Verify slider displays actual applied duration (0.5s), not requested (10s)
+      valueDisplay = container.querySelector('.ytgif-slider-value');
+      expect(valueDisplay).toHaveTextContent('0.5s');
+    });
+
+    it('should synchronize slider value when timeline handles move start position', () => {
+      const { container, rerender } = render(<TimelineScrubber {...defaultProps} duration={10} startTime={2} endTime={7} />);
+
+      // Initial duration: 5s
+      let valueDisplay = container.querySelector('.ytgif-slider-value');
+      expect(valueDisplay).toHaveTextContent('5.0s');
+
+      // Simulate moving start handle near the end (startTime: 8, endTime: 7 is invalid, so it should adjust)
+      rerender(<TimelineScrubber {...defaultProps} duration={10} startTime={8} endTime={10} />);
+
+      // Duration should now be 2s (10 - 8)
+      valueDisplay = container.querySelector('.ytgif-slider-value');
+      expect(valueDisplay).toHaveTextContent('2.0s');
+
+      // Max slider value should also update
+      const slider = screen.getByRole('slider', { name: /GIF duration/i });
+      expect(slider).toHaveAttribute('max', '2');
+    });
+
+    it('should prevent slider from exceeding remaining video duration on very short videos', () => {
+      // Start with a smaller duration, then test increasing it beyond video bounds
+      const { container } = render(<TimelineScrubber {...defaultProps} duration={8} startTime={7} endTime={7.5} />);
+      const slider = screen.getByRole('slider', { name: /GIF duration/i });
+
+      // Only 1 second remaining from start position
+      expect(slider).toHaveAttribute('max', '1');
+
+      // Initial value should be 0.5s
+      let valueDisplay = container.querySelector('.ytgif-slider-value');
+      expect(valueDisplay).toHaveTextContent('0.5s');
+
+      // Try to drag to a longer duration (5s)
+      fireEvent.change(slider, { target: { value: '5' } });
+
+      // Should be clamped to max remaining duration (1s)
+      expect(defaultProps.onRangeChange).toHaveBeenCalledWith(7, 8);
+
+      // Verify slider displays actual applied duration (1.0s), not requested (5s)
+      valueDisplay = container.querySelector('.ytgif-slider-value');
+      expect(valueDisplay).toHaveTextContent('1.0s');
     });
   });
 


### PR DESCRIPTION
For videos < 20 seconds, when a clip duration exceeds remaining video time, the timeline selection would extend outside its container and display incorrect duration values.

Changes:
- TimelineScrubber: Display actual applied duration instead of requested value
- CSS: Add overflow:hidden to timeline track to prevent visual overflow
- Tests: Add 3 unit tests and 2 E2E tests for short video edge cases

Fixes issue where slider showed "10.0s" when only 2s was available. Now correctly displays "2.0s" (the actual applied duration).

All tests passing: 34 suites (887 tests) + 2 new E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)