### PR TITLE
Bump version to 1.0.6

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "YTgify",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Turn your favorite YouTube moments into shareable GIFs.",
   "author": "Jeremy Watt",
   "homepage_url": "https://github.com/neonwatty/ytgify",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ytgify",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ytgify",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
         "@radix-ui/react-slider": "^1.3.6",
         "class-variance-authority": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ytgify",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Turn your favorite YouTube moments into shareable GIFs.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Updated version number from 1.0.5 to 1.0.6 in:
- package.json
- manifest.json
- package-lock.json

Closes #34

Generated with [Claude Code](https://claude.ai/code)