### PR TITLE
ci: add cross-repo integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -114,9 +114,9 @@ jobs:
         run: |
           bin/rails runner "
             User.find_or_create_by!(email: 'test@example.com') do |u|
+              u.username = 'testuser'
               u.password = 'password123'
               u.password_confirmation = 'password123'
-              u.confirmed_at = Time.current
             end
             puts '✓ Test user seeded: test@example.com / password123'
           "

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -180,8 +180,8 @@ jobs:
           Xvfb :99 -screen 0 1920x1080x24 &
           sleep 2
 
-          # Run tests in headed mode (required for content script injection)
-          npm run test:e2e:upload -- --headed
+          # Run e2e tests in headed mode (required for content script injection)
+          npm run test:e2e:headed
 
       - name: Upload test artifacts on failure
         if: failure()

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,206 @@
+# Integration Tests Workflow for Chrome Extension (ytgify)
+# Copy this file to: .github/workflows/integration-tests.yml in the ytgify repo
+
+name: Integration Tests
+
+on:
+  # Triggered by backend repo changes
+  repository_dispatch:
+    types: [backend-integration-test]
+
+  # Triggered on extension changes
+  push:
+    branches: [main, develop]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'package.json'
+      - '.github/workflows/integration-tests.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'package.json'
+      - '.github/workflows/integration-tests.yml'
+
+  # Manual trigger
+  workflow_dispatch:
+    inputs:
+      backend_branch:
+        description: 'Backend branch to test against'
+        required: false
+        default: 'main'
+
+permissions:
+  contents: read
+
+jobs:
+  integration-tests:
+    name: Extension ↔ Backend Integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/ytgify_share_test
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ytgify_share_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: Checkout extension
+        uses: actions/checkout@v4
+
+      - name: Determine backend ref
+        id: backend-ref
+        run: |
+          if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+            echo "ref=${{ github.event.client_payload.backend_ref }}" >> $GITHUB_OUTPUT
+            echo "branch=${{ github.event.client_payload.backend_branch }}" >> $GITHUB_OUTPUT
+          elif [[ -n "${{ github.event.inputs.backend_branch }}" ]]; then
+            echo "ref=" >> $GITHUB_OUTPUT
+            echo "branch=${{ github.event.inputs.backend_branch }}" >> $GITHUB_OUTPUT
+          else
+            echo "ref=" >> $GITHUB_OUTPUT
+            echo "branch=main" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout backend
+        uses: actions/checkout@v4
+        with:
+          repository: mean-weasel/ytgify-fullstack
+          ref: ${{ steps.backend-ref.outputs.ref || steps.backend-ref.outputs.branch }}
+          path: backend
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version-file: backend/ytgify-share/.ruby-version
+          bundler-cache: true
+          working-directory: backend/ytgify-share
+
+      - name: Install extension dependencies
+        run: npm ci
+
+      - name: Setup test database
+        working-directory: backend/ytgify-share
+        run: |
+          bin/rails db:test:prepare
+          mkdir -p tmp/storage
+          chmod 755 tmp/storage
+          echo "✓ Database prepared"
+
+      - name: Seed test user
+        working-directory: backend/ytgify-share
+        run: |
+          bin/rails runner "
+            User.find_or_create_by!(email: 'test@example.com') do |u|
+              u.password = 'password123'
+              u.password_confirmation = 'password123'
+              u.confirmed_at = Time.current
+            end
+            puts '✓ Test user seeded: test@example.com / password123'
+          "
+
+      - name: Start Rails server
+        working-directory: backend/ytgify-share
+        run: |
+          RAILS_LOG_TO_STDOUT=true bin/rails server -p 3000 &
+          RAILS_PID=$!
+          echo "Rails PID: $RAILS_PID"
+
+          echo "Waiting for Rails server..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3000/api/v1/auth/me > /dev/null 2>&1 || [ $? -eq 22 ]; then
+              echo "✓ Rails server ready (attempt $i)"
+              break
+            fi
+            if ! kill -0 $RAILS_PID 2>/dev/null; then
+              echo "✗ Rails server died"
+              exit 1
+            fi
+            echo "  Waiting... ($i/30)"
+            sleep 2
+          done
+
+      - name: Verify Rails server
+        run: |
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/api/v1/auth/me)
+          echo "Auth endpoint: HTTP $HTTP_CODE (401 expected for unauthenticated)"
+          if [[ "$HTTP_CODE" != "401" ]]; then
+            echo "Warning: Unexpected status code"
+          fi
+          echo "✓ Rails server verified"
+
+      - name: Build extension
+        run: npm run build
+
+      - name: Install FFmpeg
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+
+      - name: Generate test videos
+        run: npm run generate:test-videos
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Install Xvfb
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+
+      - name: Run integration tests
+        env:
+          REAL_BACKEND: "true"
+          BACKEND_URL: http://localhost:3000
+          DISPLAY: ":99"
+        run: |
+          # Start virtual display for headed mode
+          Xvfb :99 -screen 0 1920x1080x24 &
+          sleep 2
+
+          # Run tests in headed mode (required for content script injection)
+          npm run test:e2e:upload -- --headed
+
+      - name: Upload test artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-results-${{ github.run_id }}
+          path: |
+            tests/test-results/
+            playwright-report/
+            backend/ytgify-share/log/test.log
+          retention-days: 14
+
+      - name: Report status
+        if: always()
+        run: |
+          if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+            echo "Triggered by backend change:"
+            echo "  Backend ref: ${{ github.event.client_payload.backend_ref }}"
+            echo "  Backend branch: ${{ github.event.client_payload.backend_branch }}"
+            echo "  PR: ${{ github.event.client_payload.pr_number }}"
+          fi
+          echo "Test status: ${{ job.status }}"


### PR DESCRIPTION
## Summary
Add integration tests workflow that verifies the full Extension → Backend API → Database flow.

## How It Works
- **Backend changes** → Backend repo triggers this workflow via `repository_dispatch`
- **Extension changes** → This workflow runs on push/PR to `src/`, `tests/`, `package.json`
- **Manual trigger** → Can specify which backend branch to test against

## Workflow Steps
1. Checkout extension and backend repos
2. Start Rails server with Postgres
3. Build extension
4. Run Playwright e2e upload tests against real backend
5. Uses Xvfb headed mode (required for Chrome content script injection)

## Test Plan
- [ ] Workflow triggers correctly on push
- [ ] Workflow triggers via repository_dispatch from backend
- [ ] Integration tests pass against real backend