### PR TITLE
fix: prevent double /api/v1 prefix in API base URL

### DIFF
--- a/src/lib/api/api-client.ts
+++ b/src/lib/api/api-client.ts
@@ -40,7 +40,13 @@ export class YtgifyApiClient {
   constructor() {
     // Use environment-specific API base URL
     const apiBaseUrl = process.env.API_BASE_URL || 'http://localhost:3000';
-    this.baseURL = `${apiBaseUrl}/api/v1`;
+
+    // Avoid double /api/v1 if already in URL
+    if (apiBaseUrl.endsWith('/api/v1')) {
+      this.baseURL = apiBaseUrl;
+    } else {
+      this.baseURL = `${apiBaseUrl}/api/v1`;
+    }
 
     console.log(`[ApiClient] Initialized with base URL: ${this.baseURL}`);
   }


### PR DESCRIPTION
## Summary
- Fix malformed API URLs when `API_BASE_URL` already contains `/api/v1`
- The `build:local` script sets `API_BASE_URL=http://localhost:3000/api/v1`, but the constructor was appending another `/api/v1`, resulting in `http://localhost:3000/api/v1/api/v1`

## Test plan
- [x] Build extension with `npm run build:local`
- [ ] Verify login works against local backend
- [ ] Test GIF upload flow