### PR TITLE
docs: add Chrome Web Store removal notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # YTgify Chrome Extension
 
+> **⚠️ Important Notice: Removed from Chrome Web Store**
+>
+> After 8 months in the Chrome Web Store and being a featured extension for 4 months, Google has removed YTgify for violating their terms of service regarding the transformation of YouTube video frames into GIFs.
+>
+> **You can still use YTgify** by installing it locally as an unpacked extension:
+>
+> 1. Download the latest release: [ytgify-v1.0.19-chrome.zip](https://ytgify.com/downloads/ytgify-v1.0.19-chrome.zip)
+> 2. Extract the ZIP to a folder on your computer
+> 3. Open Chrome and go to `chrome://extensions/`
+> 4. Enable "Developer mode" (top right toggle)
+> 5. Click "Load unpacked" and select the extracted folder
+>
+> The extension works exactly the same way - it just won't auto-update. Check back here or follow [@neonwatty](https://x.com/neonwatty) for updates.
+
+---
+
 A Chrome extension that enables users to create GIFs directly from YouTube videos with an intuitive visual interface integrated into the YouTube player.
 
 https://github.com/user-attachments/assets/6b9e72b6-032a-430d-9e4c-1d637f9aec20

--- a/tests/unit/constants/links.test.ts
+++ b/tests/unit/constants/links.test.ts
@@ -65,7 +65,8 @@ describe('External Links', () => {
       );
     });
 
-    it('should return a reachable Chrome Web Store page', async () => {
+    // Skipped: Extension was removed from Chrome Web Store
+    it.skip('should return a reachable Chrome Web Store page', async () => {
       const link = getReviewLink();
       const { statusCode } = await httpsGet(link);
       // Chrome Web Store returns 200 for valid extension pages
@@ -110,7 +111,8 @@ describe('External Links', () => {
       expect(url.searchParams.get('utm_campaign')).toBe('waitlist');
     });
 
-    it('should return a reachable waitlist page', async () => {
+    // Skipped: Waitlist page no longer exists after discontinuation
+    it.skip('should return a reachable waitlist page', async () => {
       const link = getWaitlistLink();
       const { statusCode } = await httpsGet(link);
       // ytgify.com should return 200 for the share page


### PR DESCRIPTION
## Summary
- Add prominent discontinuation notice to README
- Include download link for local installation
- Provide 5-step installation instructions

## Context
After 8 months in Chrome Web Store and 4 months as a featured extension, Google removed YTgify for ToS violation regarding YouTube frame transformation to GIFs.

Users can still install the extension locally as an unpacked extension.

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify download link points to correct zip file